### PR TITLE
Code revision

### DIFF
--- a/Cshape_functions_rev.py
+++ b/Cshape_functions_rev.py
@@ -1,0 +1,541 @@
+"""
+Define functions useful for the experiment script
+
+"""
+
+import os
+import time
+import numpy as np
+
+from psychopy import visual as vis
+from psychopy import gui, core, event
+
+if __name__ != '__main__':
+    print('Cshape_functions imported..\n\n')
+    time.sleep(.5)
+
+#######################
+##     FUNCTIONS     ##
+#######################
+
+# Just the mask for participant info.
+
+
+def GUI(implicit, practice, wdir):
+
+    already_exists = True
+
+    while already_exists:
+        if not practice:
+            info = {
+                'Participant\'s name': '',
+                'Age': '',
+                'Gender': ['Male', 'Female', 'Other'],
+                'Participant number': '',
+                'Handedness': ['Right', 'Left']
+            }
+        else:
+            info = {'Participant\'s name': '', 'Participant number': ''}
+
+        infoDLG = gui.DlgFromDict(info, title='Welcome!')
+
+        if not infoDLG.OK:
+            print('CANCELLED!')
+            core.quit()
+
+        PN = info['Participant number']
+        part_name = info['Participant\'s name']
+        if len(part_name) > 0:
+            if True in [a.isspace() for a in part_name]:
+                part_name = part_name[:part_name.index(' ')]
+            if part_name[0].islower():
+                part_name = part_name.capitalize()
+
+        if not practice:
+            hand = info['Handedness']
+            age = info['Age']
+            gender = info['Gender']
+
+        if practice:
+            dataframe_name = wdir + '\\data\\part_n_' + PN + '\\Practice' +\
+            ('_implicit_' if implicit else '_') + PN + '.csv'
+            file_name = wdir + '\\data\\part_n_' + PN + '\\Practice_response' +\
+            ('_implicit_' if implicit else '_') + PN + '.csv'
+        else:
+            dataframe_name = wdir + '\\data\\part_n_' + PN + '\\Dataframe' +\
+            ('_implicit_' if implicit else '_') + PN + '.csv'
+            file_name = wdir + '\\data\\part_n_' + PN + '\\Response' +\
+            ('_implicit_' if implicit else '_') + PN + '.csv'
+
+        if not os.path.isfile(file_name):
+            already_exists = False
+
+        else:
+            myDlg2 = gui.Dlg(title="FileName Error")
+            myDlg2.addText(
+                'File name \'%s\' already exists!! Change participant number or delete the file!'
+                % file_name)
+            myDlg2.show()
+
+        if not os.path.isfile(dataframe_name):
+            myDlg2 = gui.Dlg(title="DataFrame Error")
+            myDlg2.addText('Dataframe not found at %s!!' % dataframe_name)
+            myDlg2.show()
+
+            core.quit()
+
+    if not practice:
+        return file_name, dataframe_name, PN, part_name, hand, age, gender
+
+    return file_name, dataframe_name, PN, part_name
+
+
+def Response(device, keyboard, time_search, allowed_keys, clock_items, row=-1):
+
+    if not keyboard:  #cedrus
+        if device.is_response_device():
+
+            # This should poll and clear all responses from the box before the actual response is expected
+            device.poll_for_response()
+            while device.has_response():
+                device.clear_response_queue()
+                device.poll_for_response()
+
+            # Set everything to None in case I have a weird answer
+            Press_key = None
+            ReleaseResponse_loc = None
+            Time_key = None
+
+            timer = core.Clock()
+            release = False
+
+            timer.reset(time_search)
+            device.reset_rt_timer()
+
+            while not release:
+
+                if timer.getTime() >= 0:
+                    Press_key = None
+                    ReleaseResponse_loc = None
+                    Time_key = None
+                    break
+
+                device.poll_for_response()
+
+                if device.has_response():
+                    resp = device.get_next_response()
+
+                    if resp['pressed']:
+                        Press_key = resp['key']
+                        Time_key = resp['time']
+                        ReleaseResponse_loc = None
+
+                    elif not resp['pressed'] and Press_key is not None:
+                        ReleaseResponse_loc = resp
+                        release = True
+
+                    else:
+                        print('Something is wrong with this response %s at trial %s'\
+                              %(resp,row))
+
+        else:
+            print('device %s is not a response device!' % device)
+    else:  #keyboard
+        ReleaseResponse_loc = None
+        resp = event.waitKeys(maxWait=time_search,
+                              keyList=allowed_keys,
+                              timeStamped=clock_items)
+        if resp is None:
+            Press_key = None
+            Time_key = None
+        else:
+            Press_key = resp[0][0]
+            Time_key = resp[0][1]
+
+    return Press_key, Time_key, ReleaseResponse_loc
+
+
+#The cedrus response is a python dict with the following keys:
+#    pressed: True if the key was pressed, False if it was released
+#    key: Response pad key pressed by the subject
+#    port: Device port the response was from (typically 0)
+#    time: value of the Response Time timer when the key was hit/released
+
+
+def Instructions(part_number, part_name, win, item, device, KeyResp, ori_targ,
+                 keyboard, quiT, allowed_keys, esc_keys, cue_prot0, cue_prot1,
+                 cue_prot2, dutch, message_dict, practice, implicit):
+
+    clockUseless = core.Clock()
+
+    def Wait_and_respond(message,
+                         device,
+                         keyboard,
+                         allowed_keys,
+                         message2=None,
+                         wait=8):
+        time.sleep(wait)
+        if message is not None:
+            message.draw()
+            if message2 is not None:
+                message2.draw()
+            win.flip()
+        Press_key, Time_key, ReleaseResponse_loc = Response(
+            device=device,
+            keyboard=keyboard,
+            time_search=900,
+            allowed_keys=allowed_keys,
+            clock_items=clockUseless)
+        if quiT and Press_key in esc_keys:
+            print('QUIT! Key %s' % Press_key)
+            win.close()
+            core.quit()
+        return Press_key
+
+    wrap = 32.5
+
+    #True when participant number is even, to switch index fingers on buttons
+    counterbalance = True if part_number % 2 == 0 else False
+    lab = ['left', 'right'] if not dutch else ['linker', 'rechter']
+
+    if not implicit:
+        recap_text = message_dict['recap_message']
+    elif counterbalance:
+        recap_text = message_dict['recap_message'].format(lab[0], lab[1])
+    else:
+        recap_text = message_dict['recap_message'].format(lab[1], lab[0])
+
+    #Parameters for cue positions in instructions
+    if not implicit:
+        triangle_side = 4
+        move_right = 4
+        move_down = 3
+        yT = ((triangle_side**2 - (triangle_side / 2)**2)**(1 / 2)) / 2
+        pos1 = (0, yT)
+
+        cuelabel = vis.TextStim(win,
+                                text='The cues' if not dutch else 'De cues',
+                                color='black',
+                                wrapWidth=wrap,
+                                height=.7,
+                                pos=((pos1[0] - move_right,
+                                      -pos1[1] - move_down - 2)),
+                                anchorVert='bottom',
+                                bold=False)
+        objmessage = vis.TextStim(win,
+                                  text=message_dict['message_objective'],
+                                  color='black',
+                                  wrapWidth=wrap,
+                                  height=1,
+                                  pos=(0, 0),
+                                  anchorVert='bottom',
+                                  bold=True)
+        textbox_3 = vis.TextStim(win,
+                                 text=message_dict['message_3_cues'],
+                                 color='black',
+                                 wrapWidth=wrap,
+                                 height=.9,
+                                 pos=(0, 5),
+                                 anchorVert='center')
+        textbox_4 = vis.TextStim(win,
+                                 text=message_dict['message_4_switch'],
+                                 color='black',
+                                 wrapWidth=wrap,
+                                 height=.9,
+                                 pos=(0, 0),
+                                 anchorVert='center')
+
+    recap = vis.TextStim(win,
+                         text=recap_text,
+                         color='black',
+                         bold=False,
+                         wrapWidth=wrap,
+                         height=1,
+                         pos=(0, 0),
+                         anchorVert='center')
+    spacetext = vis.TextStim(win,
+                             text=message_dict['space'].format(
+                                 message_dict['buttoN']),
+                             color='white',
+                             wrapWidth=wrap,
+                             height=.5,
+                             pos=(0, -8.5),
+                             anchorVert='bottom')
+    testtext = vis.TextStim(win,
+                            text=message_dict['test1'].format(
+                                message_dict['buttoN']),
+                            color='white',
+                            wrapWidth=wrap,
+                            height=.8,
+                            pos=(0, -7.5),
+                            anchorVert='bottom')
+    textbox_1 = vis.TextStim(
+        win,
+        text=message_dict['message_1_welcome'].format(part_name),
+        color='black',
+        wrapWidth=wrap,
+        height=.9,
+        pos=(0, 0),
+        anchorVert='center')
+    textbox_2 = vis.TextStim(win,
+                             text='def',
+                             color='black',
+                             wrapWidth=wrap,
+                             height=.9,
+                             pos=(0, 4),
+                             anchorVert='center')
+    textbox_5 = vis.TextStim(win,
+                             text=message_dict['message_5_questions'],
+                             color='black',
+                             bold=True,
+                             wrapWidth=wrap,
+                             height=1.2,
+                             pos=(0, 0),
+                             anchorVert='center')
+    textbox_6 = vis.TextStim(win,
+                             text=message_dict['message_6'],
+                             color='black',
+                             bold=False,
+                             wrapWidth=wrap,
+                             height=.8,
+                             pos=(0, -4),
+                             anchorVert='center')
+    textbox_final = vis.TextStim(
+        win,
+        text=message_dict['message_final'].format(part_name),
+        color='black',
+        bold=False,
+        wrapWidth=wrap,
+        height=1.2,
+        pos=(0, 0),
+        anchorVert='center')
+
+    if practice:
+        if counterbalance:
+            textbox_2.text = message_dict['message_2_target'].format(
+                lab[0], lab[1]
+            )  #for even participant, switch hands (left index on the top)
+        else:
+            textbox_2.text = message_dict['message_2_target'].format(
+                lab[1], lab[0]
+            )  # for uneven participant, switch hands (right index on the top)
+        textbox_1.draw()
+        win.flip()
+        Wait_and_respond(message=spacetext,
+                         device=device,
+                         keyboard=keyboard,
+                         allowed_keys=allowed_keys,
+                         message2=textbox_1)
+        textbox_2.draw()
+        win.flip()
+        Wait_and_respond(message=testtext,
+                         device=device,
+                         keyboard=keyboard,
+                         allowed_keys=allowed_keys,
+                         message2=textbox_2)
+
+        item.pos = (0, -5)
+        ori = ori_targ * 2
+        np.random.shuffle(ori)
+        right_resp = [KeyResp[0] if r == 90 else KeyResp[1] for r in ori]
+        item.fillColor = 'black'
+        count = 0
+        while count < 4:
+            for x in range(4):
+                time.sleep(.7)
+                item.ori = ori[x]
+                item.draw()
+                textbox_2.draw()
+                testtext.text = 'Respond correctly to these targets to continue!'\
+                                if not dutch else 'Reageer correct op deze target stimuli om door te gaan!'
+                testtext.draw()
+                win.flip()
+                Press_key = Wait_and_respond(message=None,
+                                             device=device,
+                                             keyboard=keyboard,
+                                             allowed_keys=allowed_keys,
+                                             wait=0)
+
+                if Press_key == right_resp[x]:
+                    item.fillColor = 'lime'
+                    testtext.draw()
+                    textbox_2.draw()
+                    item.draw()
+                    win.flip()
+                    time.sleep(.3)
+                    count += 1
+                else:
+                    item.fillColor = 'crimson'
+                    testtext.draw()
+                    textbox_2.draw()
+                    item.draw()
+                    win.flip()
+                    time.sleep(.3)
+                    count = -2
+                item.fillColor = 'black'
+
+        if not implicit:
+            textbox_3.draw()
+            cue_prot0.draw()
+            cue_prot1.draw()
+            cue_prot2.draw()
+            cuelabel.draw()
+            win.flip()
+            textbox_3.draw()
+            cue_prot0.draw()
+            cue_prot1.draw()
+            cue_prot2.draw()
+            cuelabel.draw()
+            Wait_and_respond(message=spacetext,
+                             device=device,
+                             keyboard=keyboard,
+                             allowed_keys=allowed_keys,
+                             wait=10)
+            objmessage.draw()
+            win.flip()
+            Wait_and_respond(message=objmessage,
+                             device=device,
+                             keyboard=keyboard,
+                             allowed_keys=allowed_keys,
+                             message2=spacetext,
+                             wait=4)
+
+            textbox_4.draw()
+            win.flip()
+            Wait_and_respond(message=textbox_4,
+                             device=device,
+                             keyboard=keyboard,
+                             allowed_keys=allowed_keys,
+                             message2=spacetext,
+                             wait=10)
+        textbox_5.draw()
+        win.flip()
+        Wait_and_respond(message=textbox_5,
+                         device=device,
+                         keyboard=keyboard,
+                         allowed_keys=allowed_keys,
+                         message2=textbox_6,
+                         wait=10)
+
+    else:  #real experiment starting
+        recap.draw()
+        win.flip()
+        Wait_and_respond(message=recap,
+                         device=device,
+                         keyboard=keyboard,
+                         allowed_keys=allowed_keys,
+                         message2=spacetext,
+                         wait=10)
+        textbox_final.draw()
+        win.flip()
+        Wait_and_respond(message=textbox_final,
+                         device=device,
+                         keyboard=keyboard,
+                         allowed_keys=allowed_keys,
+                         message2=None,
+                         wait=.1)
+
+
+def breaK(implicit,
+          win,
+          device,
+          keyboard,
+          allowed_keys,
+          clock_items,
+          row,
+          response,
+          rt,
+          dutch,
+          crash,
+          message_dict,
+          time_search=500000,
+          row_start=0):
+
+    if crash:
+        acc = len(response[response == 1]) / (row - row_start) * 100
+        rts = np.mean(rt[rt > 0][row_start:row])
+
+    else:
+        acc = len(response[response == 1]) / (row) * 100
+        rts = np.mean(rt[rt > 0][:row])
+
+    string = 'Let\'s have a break!\n\nYour mean reaction time is {}ms!\n\n\
+You accuracy is {}%!'                      if not dutch else \
+    'Laten we een pauze nemen! Je gemiddelde reactietijd is {}ms!\n\nJe nauwkeurigheid is {}%!'
+    string2 = 'Are you ready? Press a button to resume the experiment!' if not dutch else\
+    'Ben je er klaar voor? Druk op een knop om het experiment te hervatten!'
+
+    message = vis.TextStim(win,
+                           wrapWidth=30,
+                           text='DEF',
+                           bold=False,
+                           pos=(0, 0),
+                           height=2,
+                           color='black')
+    if keyboard:
+        message.text = string.format(int(round(rts * 1000)), round(acc))
+    else:
+        message.text = string.format(int(round(rts)), round(acc))
+    message.draw()
+    win.flip()
+    Response(device, keyboard, time_search, allowed_keys, clock_items)
+    if not implicit:
+        message.text = message_dict['important_message_remember']
+        message.wrapWidth = 32
+        message.height = 1
+        message.draw()
+        win.flip()
+        time.sleep(8)
+        Response(device, keyboard, time_search, allowed_keys, clock_items)
+    message1 = vis.TextStim(win,
+                            wrapWidth=25,
+                            text=string2,
+                            bold=True,
+                            pos=(0, 0),
+                            height=2,
+                            color='black')
+    message1.draw()
+    win.flip()
+    Response(device, keyboard, time_search, allowed_keys, clock_items)
+
+
+#define function for translating colors for draw search array
+def C_color_position(positions, position_target, color_labels, color_target):
+
+    position_arr = np.split(positions, len(color_labels))
+    #Return in which chunk of positions is the target
+    index_position_target = [position_target in i
+                             for i in position_arr].index(True)
+    index_color = color_labels.index(color_target)
+
+    while index_position_target != index_color:
+        color_labels = color_labels[1:] + color_labels[:1]
+        index_color = color_labels.index(color_target)
+
+    final_colors = []
+    for pos, color in zip(position_arr, color_labels):
+        for _ in pos:
+            final_colors.append(color)
+
+    return final_colors
+
+
+def WrongAnswer(keyboard, question, answer, warning, win, device, rowI, keyss):
+    useless_clock = core.Clock()
+    if keyboard:
+        while answer not in keyss:
+            question.draw()
+            warning.draw()
+            win.flip()
+            answer = Response(device = device, keyboard = keyboard,
+                                  time_search = 9000, allowed_keys = None,\
+                                  clock_items = useless_clock, row = rowI)[0]
+    else:
+        while answer not in keyss:
+            question.draw()
+            warning.draw()
+            win.flip()
+            answer = Response(device = device, keyboard = keyboard,
+                                  time_search = 9000, allowed_keys = None,\
+                                  clock_items = useless_clock, row = rowI)[0]
+    return answer

--- a/Cshape_rev.py
+++ b/Cshape_rev.py
@@ -1,0 +1,989 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Oct 2 15:11:32 2019
+
+@author: Jacopo
+q
+Experimental procedure script for the visual search task - explicit mode.\
+Data is imported from a dataframe and the response is saved in a csv.
+Info of the participant is saved in a txt.
+"""
+
+import time
+import random
+import warnings
+import numpy as np
+import pandas as pd
+
+from psychopy import visual as vis, core
+
+from Cshape_functions_rev import (Response, Instructions, breaK, GUI,
+                                   WrongAnswer, C_color_position)
+
+from Messages import message_dict
+
+#Import useful variables from init script
+from Init_Cshape_rev import (headers, headers_answer, trials_total,
+                              color_labels, number_positions, keyboard,
+                              color_space, time_placeholder, time_cues,
+                              time_search, KeyResp, quiT, ms_to_frames,
+                              row_save, mon, esc_keys, allowed_keys, dutch,
+                              break_time, row_crash, crash, practice, implicit,
+                              iti_max, iti_min, fix_max, fix_min, wdir)
+
+if implicit:
+    from Init_Cshape_rev import (keys_4_answ_reduced, keys_4_answ)
+else:
+    from Init_Cshape_rev import hints
+
+print('Executing Cshape script!\n\n')
+time.sleep(.5)
+
+if not practice:
+    file_name, dataframe_name, PN, part_name, hand, age, gender = GUI(
+        implicit, practice, wdir)
+else:
+    file_name, dataframe_name, PN, part_name = GUI(implicit, practice, wdir)
+
+# Save participant info file if we are not in practice mode.
+#Will be updated at the end with the total time.
+if not practice and not crash:
+    try:
+        info_file = open(
+            wdir + '\\data\\part_n_' + PN + '\\info_' + PN + '.txt', 'x')
+    except FileExistsError as e:
+        print(e)
+        core.quit()
+    info_file.write('file_name = ' + file_name + '\n' + 'dataframe_name = ' +
+                    dataframe_name + '\n' + 'Participant number = ' + PN +
+                    '\n' + 'hand = ' + hand + '\n' + 'age = ' + age + '\n' +
+                    'gender = ' + gender + '\n')
+    info_file.close()
+
+counterbalance = True if int(
+    PN) % 2 == 0 else False  #True when participant number is even
+
+if not keyboard:
+    import pyxid2 as pyxid
+else:
+    from psychopy import event
+
+##############################
+##     IMPORT DATAFRAME     ##
+##############################
+
+df = pd.read_csv(filepath_or_buffer=dataframe_name,
+                 header=0,
+                 names=['Index'] + headers,
+                 engine='python')
+
+##Transform dataframes values so that they are meaningful for psychopy
+#Define functions for such transformation
+color_func = lambda x: color_labels[0] if x == 0 else\
+            (color_labels[1] if x == 1 else color_labels[2])
+ori_func_targ = lambda x: 90 if x == 0 else 270  # 90 has gap in the bottom, gap is up when ori is 270
+ori_func_distr = lambda x: 180 if x == 1 else x
+
+# Apply functions
+if keyboard:
+    cor_resp_func = lambda x: 'down' if x == 0 else 'up'
+    df.loc[:, 'correct_response'] = df.correct_response.apply(cor_resp_func)
+
+if implicit:
+    df.loc[:, 'color_target'] = df.loc[:, 'color_target'].apply(color_func)
+else:
+    for col in df.loc[:, 'color_target':'color_cue2']:
+        df.loc[:, col] = df.loc[:, col].apply(color_func)
+
+df.loc[:, 'ori_target'] = df.ori_target.apply(ori_func_targ)
+
+for col1 in df.loc[:, 'ori_distractor_0':'ori_distractor_11']:
+    df.loc[:, col1] = df.loc[:, col1].apply(ori_func_distr)
+
+# Reaction times
+RTs_cedrus = np.repeat(-1., trials_total)
+RTs_keyboard = np.repeat(-1., trials_total)
+
+# Just check the timings of the different windows flipped.
+trial_time = np.repeat(-1., trials_total)
+items_time = np.repeat(-1., trials_total)
+placeholder_time = np.repeat(-1., trials_total)
+cue_time = np.repeat(-1., trials_total)
+
+# Response variables
+if keyboard:
+    response_key = ['nope'] * trials_total  # Which key was pressed
+else:
+    response_key = np.repeat(-1., trials_total)  # Which key was pressed
+
+is_response_right = np.repeat(-1., trials_total)  # Is it the right response?
+# ONLY for Cedrus, how long the button has been pressed?
+button_pressed = np.repeat(-1., trials_total)
+guessed_cues = np.repeat(-1., trials_total)
+Key4cues = ['1', '2', '3']
+
+########################
+##     CEDRUS BOX     ##
+########################
+
+if not keyboard:
+    pyxid.use_response_pad_timer = True
+    device = pyxid.get_xid_devices()[0]
+    time.sleep(1)
+else:
+    device = None
+
+########################
+##     PARAMETERS     ##
+########################
+
+# Set parameters for search items' features
+sizeItem = 1.5
+
+# Set parameters for real positions
+PS = 12 / 5.3  #divide each quadrant in 3 equal parts
+
+# Adjust the y and x of the items close to the axis
+mod = 1.32
+# Define all 12 positions of the search array, these will be the pos attribute of the search items
+positionReal = [(PS / mod, 3 * PS), (2 * PS, 2 * PS), (3 * PS, PS / mod),
+                (3 * PS, -PS / mod), (2 * PS, -2 * PS), (PS / mod, -3 * PS),
+                (-PS / mod, -3 * PS), (-2 * PS, -2 * PS), (-3 * PS, -PS / mod),
+                (-3 * PS, PS / mod), (-2 * PS, 2 * PS), (-PS / mod, 3 * PS)]
+
+# Set parameters for cues
+r = .4
+size_c = 1
+d = 3
+f = -2
+#cues are in a triangular position, with these dimensions
+triangle_side = 4
+yT = ((triangle_side**2 - (triangle_side / 2)**2)**(1 / 2)) / 2
+xT = triangle_side / 2
+#position for cue0, cue1 and cue2
+pos0 = (-xT, -yT)
+pos1 = (0, yT)
+pos2 = (xT, -yT)
+
+# Placeholder parameters
+w = 1.4
+h1 = 1.4
+size_p = 1
+lineW = 3.5
+
+# Fixation cross vertices
+a = .05  # x-axis top-right edge
+c = .2 + a  # 'lenght' of one part of the cross
+FixVert = ((a, -c), (a, -a), (c, -a), (c, a), (a, a), (a, c), (-a, c), (-a, a),
+           (-c, a), (-c, -a), (-a, -a), (-a, -c))
+
+# Set coordinates of the vertices and the gap for the C shape (search item)
+x, y = (.6, .6)
+g, h = (.3, .3)
+gap = .2
+
+# If gap == 0 then the shape is a square without one side.
+#This is just a note not important for execution.
+if gap < 0 or gap > g:
+    raise Exception(
+        'set a proper gap value for the polygon: gap should be between 0 and %s'
+        % g)
+
+######################################
+##     VISUAL PART AND STIMULI      ##
+######################################
+
+if 'test' in mon.name:
+    warnings.warn('Using Test monitor!!')
+
+# Make sure we are using gamma calibration if monitor is Benq
+if 'Jacop' not in mon.name and 'test' not in mon.name:
+    if mon.gammaIsDefault():
+        raise Exception('Monitor is not using gamma!!')
+
+# Create the window
+gray = (0,0,.5) if color_space == 'hsv' else\
+        ((0,0,0,) if color_space == 'rgb' else 'gray')
+win = vis.Window(fullscr=True,
+                 winType='pyglet',
+                 color=gray,
+                 monitor=mon,
+                 units='deg',
+                 gammaErrorPolicy='ignore',
+                 colorSpace=color_space)  #monitor = 'Benq_xl2411'
+win.allowGUI = False
+win.mouseVisible = False
+
+# Define the 12 polygon vertices
+CVert = ((x, h - gap), (x, y), (-x, y), (-x, -y), (x, -y), (x, (-h + gap)),
+         (g, (-h + gap)), (g, -h), (-g, -h), (-g, h), (g, h), (g, h - gap))
+
+#Initialize C shape
+C = vis.ShapeStim(win,
+                  vertices=CVert,
+                  fillColor=[0, 0, 0],
+                  lineWidth=0,
+                  size=sizeItem,
+                  pos=(0, 0),
+                  ori=25,
+                  fillColorSpace=color_space)
+C_prot = vis.ShapeStim(win,
+                       vertices=CVert,
+                       fillColor=[0, 0, 0],
+                       lineWidth=0,
+                       size=sizeItem,
+                       pos=(0, 0),
+                       ori=25,
+                       fillColorSpace=color_space)
+
+# Initialize Placeholders
+Place_Holder0 = vis.Rect(win,
+                         width=w,
+                         height=h1,
+                         size=size_p,
+                         lineWidth=lineW,
+                         lineColor='black',
+                         pos=pos0)
+Place_Holder1 = vis.Rect(win,
+                         width=w,
+                         height=h1,
+                         size=size_p,
+                         lineWidth=lineW,
+                         lineColor='black',
+                         pos=pos1)
+Place_Holder2 = vis.Rect(win,
+                         width=w,
+                         height=h1,
+                         size=size_p,
+                         lineWidth=lineW,
+                         lineColor='black',
+                         pos=pos2)
+
+# Initialize cues
+C0 = vis.Circle(win,
+                size=size_c,
+                radius=r,
+                lineWidth=0,
+                fillColor=[0, 0, 0],
+                fillColorSpace=color_space,
+                pos=pos0)
+C1 = vis.Circle(win,
+                size=size_c,
+                radius=r,
+                lineWidth=0,
+                fillColor=[0, 0, 0],
+                fillColorSpace=color_space,
+                pos=pos1)
+C2 = vis.Circle(win,
+                size=size_c,
+                radius=r,
+                lineWidth=0,
+                fillColor=[0, 0, 0],
+                fillColorSpace=color_space,
+                pos=pos2)
+
+#Cues that appear in instructions!
+move_right = 4
+move_down = 3
+cue_prot0 = vis.Circle(win,
+                       size=1.2,
+                       radius=r,
+                       lineWidth=0,
+                       fillColor='green',
+                       pos=(pos0[0] - move_right, pos0[1] - move_down))
+cue_prot1 = vis.Circle(win,
+                       size=1.2,
+                       radius=r,
+                       lineWidth=0,
+                       fillColor='red',
+                       pos=(pos1[0] - move_right, pos1[1] - move_down))
+cue_prot2 = vis.Circle(win,
+                       size=1.2,
+                       radius=r,
+                       lineWidth=0,
+                       fillColor='blue',
+                       pos=(pos2[0] - move_right, pos2[1] - move_down))
+
+# Fixation cross
+fixation = vis.ShapeStim(win,
+                         vertices=FixVert,
+                         fillColor='black',
+                         lineWidth=0,
+                         size=1,
+                         pos=(0, 0))
+
+# Just a hint to visualize which is the predictive cue and which is the
+# validity, to have a feeling of how a trial may look like!
+if not implicit:
+    if hints:
+        Hint = vis.TextStim(win,
+                            height=.6,
+                            pos=(0, -4),
+                            color='black',
+                            bold=True)
+
+# Feedback messages
+if not implicit:
+    switch_message = vis.TextStim(win,
+                                  text=message_dict['switch_text'],
+                                  wrapWidth=30,
+                                  height=1.7,
+                                  pos=(0, 0),
+                                  color='black',
+                                  bold=False)
+    invalid_message = vis.TextStim(win,
+                                   text=message_dict['invalid_hint'],
+                                   wrapWidth=30,
+                                   height=1.7,
+                                   pos=(0, 0),
+                                   color='black',
+                                   bold=False)
+    no_more_mess = vis.TextStim(win,
+                                text=message_dict['no_more_mess_text'],
+                                wrapWidth=30,
+                                height=1,
+                                pos=(0, 0),
+                                color='black',
+                                bold=False)
+
+wrong_key = vis.TextStim(win,
+                         text=message_dict['wrong_key_text'],
+                         height=.6,
+                         pos=(0, 0),
+                         color='red',
+                         bold=True)
+late_answ = vis.TextStim(win,
+                         text=message_dict['late_answer_text'],
+                         height=.6,
+                         pos=(0, 0),
+                         color='red',
+                         bold=True)
+end_practice_message = vis.TextStim(win,
+                                    text=message_dict['end_practice'],
+                                    color='black',
+                                    bold=False,
+                                    wrapWidth=32,
+                                    height=1,
+                                    pos=(0, 0),
+                                    anchorVert='center')
+neg_feedback = vis.TextStim(win,
+                            text=message_dict['neg_feedback_text'],
+                            height=.6,
+                            pos=(0, 0),
+                            color='crimson',
+                            bold=True,
+                            wrapWidth=30)
+pos_feedback = vis.TextStim(win,
+                            text='Default',
+                            height=.6,
+                            pos=(0, 0),
+                            color='green',
+                            bold=True,
+                            wrapWidth=30)
+
+#Limits in milliseconds for giving different feedbacks
+if practice:
+    limits = np.array([750, 950, 1650, 2100,
+                       3000])  # For positive feedback during pratice
+    if keyboard:
+        limits = limits / 1000  # For positive feedback during pratice
+
+############################
+##     INSTRUCTIONS       ##
+############################
+
+Instructions(part_number=int(PN),
+             part_name=part_name,
+             win=win,
+             item=C_prot,
+             device=device,
+             KeyResp=KeyResp,
+             ori_targ=[90, 270],
+             keyboard=keyboard,
+             quiT=quiT,
+             allowed_keys=allowed_keys,
+             esc_keys=esc_keys,
+             cue_prot0=cue_prot0,
+             cue_prot1=cue_prot1,
+             cue_prot2=cue_prot2,
+             dutch=dutch,
+             message_dict=message_dict,
+             practice=practice,
+             implicit=implicit)
+core.wait(1)
+
+breaks = []
+break_row = []
+
+####################################
+##     EXPERIMENTAL PROCEDURE     ##
+####################################
+
+# Initialize some clocks to check the timings and to get reaction times
+total_clock = core.Clock()
+clock_placeholder = core.Clock()
+clock_cues = core.Clock()
+clock_items = core.Clock()
+clock_trial = core.Clock()
+break_clock = core.Clock()
+break_clock.reset(break_time * 60)  #Set break timer
+
+if not keyboard:
+    device.reset_base_timer()  #should be called just before first trial
+
+if not implicit:
+    ms = 5000  #milliseconds for time_cues to reduce the timing during practice
+
+# Repeat for the number of trials
+for rowI in range(row_crash, trials_total):
+
+    if not implicit:
+        if practice and rowI == 12:
+            switch_message.draw()
+            win.flip()
+            time.sleep(5)
+
+        if practice and rowI == trials_total - 10:
+            no_more_mess.draw()
+            win.flip()
+            time.sleep(5)
+
+# Set cue identity
+    cue_identity_temp = df.loc[rowI, 'cue_identity_def']
+    cue_validity_temp = df.loc[rowI, 'cue_validity_def']
+
+    # Make a break after break_time has passed
+    if not practice and break_clock.getTime() > 0:
+        rest_clock = core.Clock()
+        breaK(implicit,
+              win,
+              device,
+              keyboard,
+              allowed_keys,
+              clock_items,
+              row=rowI + 1,
+              response=is_response_right,
+              rt=RTs_keyboard if keyboard else RTs_cedrus,
+              dutch=dutch,
+              crash=crash,
+              message_dict=message_dict,
+              row_start=row_crash)
+
+        breaks.append(rest_clock.getTime())
+        break_row.append(rowI)
+        break_clock.reset(break_time * 60)
+
+# Randomize positions for search items
+    start_position = df.loc[rowI, 'Start_position']
+    positionIndexTrue = np.arange(start_position,
+                                  start_position + number_positions,
+                                  dtype='int')
+    positionIndexTrue[
+        positionIndexTrue >= number_positions] -= number_positions
+
+    # Randomize stimuli orientation
+    position_target = df.loc[rowI, 'position_target']
+    ori_vector = df.loc[rowI, 'ori_distractor_0':'ori_distractor_11']
+    ori_target = df.loc[rowI, 'ori_target']
+
+    # Set cue and target colors
+    if not implicit:
+        C0.fillColor = df.loc[rowI, 'color_cue0']
+        C1.fillColor = df.loc[rowI, 'color_cue1']
+        C2.fillColor = df.loc[rowI, 'color_cue2']
+
+    color_target = df.loc[rowI, 'color_target']
+
+    #rotate the color array to draw correctly based on color and position of the target
+    final_colors = C_color_position(positions=positionIndexTrue,
+                                    position_target=position_target,
+                                    color_labels=color_labels,
+                                    color_target=color_target)
+
+    # Just the hint
+    if not implicit:
+        if hints:
+            if not dutch:
+                cue_id_label = 'left' if cue_identity_temp == 0 else (
+                    'top' if cue_identity_temp == 1 else 'right')
+            else:
+                cue_id_label = 'linker' if cue_identity_temp == 0 else (
+                    'hoogste' if cue_identity_temp == 1 else 'rechterkant')
+            string = message_dict['hint_text'].format(cue_id_label)
+            Hint.text = string
+#           string2 = 'Position first is %s\nPostionTarget is %s\nTarget color is %s'%(start_position, position_target, color_target)
+#           Hint2.text = string2
+
+#####################
+##     DRAWING     ##
+#####################
+
+    clock_trial.reset()
+
+    # Placeholder and cue draw
+    if not implicit:
+        clock_placeholder.reset()
+
+        #This should present the stimuli for 30-54 frames (corresponds to 500-900 ms)
+        for frame in time_placeholder:
+            fixation.draw()
+            if hints:
+                if rowI < 20:
+                    Hint.draw()
+                if rowI <= 11:
+                    Place_Holder0.draw()
+                elif rowI < 20:
+                    Place_Holder1.draw()
+                else:
+                    Place_Holder0.draw()
+                    Place_Holder1.draw()
+                    Place_Holder2.draw()
+            else:
+                Place_Holder0.draw()
+                Place_Holder1.draw()
+                Place_Holder2.draw()
+            win.flip()
+        placeholder_time[rowI] = clock_placeholder.getTime()
+        clock_cues.reset()
+
+        for frame in time_cues:
+            fixation.draw()
+            if hints:
+                if rowI < 20:
+                    Hint.draw()
+                if rowI <= 11:
+                    Place_Holder0.draw()
+                elif rowI < 20:
+                    Place_Holder1.draw()
+                else:
+                    Place_Holder0.draw()
+                    Place_Holder1.draw()
+                    Place_Holder2.draw()
+            else:
+                Place_Holder0.draw()
+                Place_Holder1.draw()
+                Place_Holder2.draw()
+            C0.draw()
+            C1.draw()
+            C2.draw()
+            win.flip()
+        cue_time[rowI] = clock_cues.getTime()
+
+    for frame in range(
+            random.randrange(ms_to_frames(fix_min), ms_to_frames(fix_max),
+                             ms_to_frames(100))):
+        fixation.draw()
+        win.flip()
+    fixation.draw()
+
+    # Search array draw. Draw 12 times the Cshape, with varying positions, colors and orientations.
+    for index_position, real_position in enumerate(positionIndexTrue):
+
+        C.fillColor = final_colors[index_position]
+        C.pos = positionReal[real_position]
+        if real_position == position_target:
+            C.ori = ori_target
+        else:
+            C.ori = ori_vector[real_position]
+        C.draw()
+
+    if keyboard:
+        event.clearEvents()
+
+    win.flip()
+    clock_items.reset()
+
+    ######################
+    ##     RESPONSE     ##
+    ######################
+
+    Press_key, Time_key, ReleaseResponse = Response(device=device,
+                                                    keyboard=keyboard,
+                                                    time_search=time_search,
+                                                    allowed_keys=allowed_keys,
+                                                    clock_items=clock_items,
+                                                    row=rowI)
+
+    # Keep track of elapsed time just for check
+    items_time[rowI] = clock_items.getTime()
+    trial_time[rowI] = clock_trial.getTime()
+
+    if Press_key is not None:
+        if not keyboard:
+            RTs_cedrus[rowI] = Time_key
+            button_pressed[rowI] = ReleaseResponse['time'] - Time_key
+        else:
+            RTs_keyboard[rowI] = round(Time_key, 4)
+        response_key[rowI] = Press_key
+
+        if Press_key == df['correct_response'][rowI]:  #correct answer
+            is_response_right[rowI] = 1
+            if practice:
+                if Time_key >= limits[4]:
+                    pos_feedback.text = message_dict['pos_feedback_1']
+                elif Time_key >= limits[3]:
+                    pos_feedback.text = message_dict['pos_feedback_2']
+                elif Time_key >= limits[2]:
+                    pos_feedback.text = message_dict['pos_feedback_3']
+                elif Time_key >= limits[1]:
+                    pos_feedback.text = message_dict['pos_feedback_4']
+                elif Time_key >= limits[0]:
+                    pos_feedback.color = 'lawnGreen'
+                    pos_feedback.text = message_dict['pos_feedback_5']
+                else:
+                    pos_feedback.color = 'lime'
+                    pos_feedback.text = message_dict['pos_feedback_6']
+                pos_feedback.draw()
+                pos_feedback.color = 'green'
+                win.flip()
+                time.sleep(3)
+
+        elif Press_key not in KeyResp:  #Quit key
+            if quiT and Press_key in esc_keys:
+                print('QUIT! Key %s' % Press_key)
+                win.close()
+                core.quit()
+
+            else:  #Pressed a wrong button
+                is_response_right[rowI] = -2
+                for frame in range(150):
+                    wrong_key.draw()
+                    win.flip()
+
+        else:  #wrong answer
+            is_response_right[rowI] = 0
+            if practice:
+                neg_feedback.draw()
+                win.flip()
+                time.sleep(4)
+
+    else:  # No answer!
+        #Should warn participant to answer more quickly
+        is_response_right[rowI] = -1
+        for frame in range(120):
+            late_answ.draw()
+            win.flip()
+
+    if not implicit:
+        if practice and df.loc[rowI, 'valid_trial'] == 0:
+            invalid_message.draw()
+            win.flip()
+            time.sleep(9)
+
+    # Inter-trial interval (with fixation cross)
+    for frame in range(
+            random.randrange(ms_to_frames(iti_min), ms_to_frames(iti_max),
+                             ms_to_frames(100))):
+        fixation.draw()
+        win.flip()
+
+    if not implicit:
+        if practice:
+            time_cues = range(ms_to_frames(ms))
+            time_search -= .19
+            ms -= 140
+
+####################
+##     ENDING     ##
+####################
+
+    if rowI == trials_total - 1:  #Last row on dataframe, end of experiment or practice
+
+        if practice:  #End of practice
+            end_practice_message.draw()
+            win.flip()
+            time.sleep(4)
+            if not implicit:
+                Response(device=device,
+                         keyboard=keyboard,
+                         time_search=60000,
+                         allowed_keys=allowed_keys,
+                         clock_items=core.Clock())
+                end_practice_message.text = message_dict[
+                    'important_message_remember']
+                end_practice_message.draw()
+                win.flip()
+                time.sleep(8)
+                Response(device=device,
+                         keyboard=keyboard,
+                         time_search=60000,
+                         allowed_keys=allowed_keys,
+                         clock_items=core.Clock())
+
+        else:  #End of real experiment
+            bye = vis.TextStim(win,
+                               text=message_dict['bye_text'],
+                               color='black',
+                               bold=True,
+                               wrapWidth=32,
+                               height=1,
+                               pos=(0, 0),
+                               anchorVert='center')
+
+            if implicit:  #Question time for implicit mode
+                question_time = vis.TextStim(
+                    win,
+                    text=message_dict['questions_text'],
+                    color='black',
+                    bold=False,
+                    wrapWidth=32,
+                    height=1,
+                    pos=(0, 0),
+                    anchorVert='center')
+                Q0 = vis.TextStim(win,
+                                  text=message_dict['Q0_text'],
+                                  color='black',
+                                  bold=False,
+                                  wrapWidth=32,
+                                  height=1,
+                                  pos=(0, 0),
+                                  anchorVert='center')
+                Q1 = vis.TextStim(win,
+                                  text=message_dict['Q1_text'],
+                                  color='black',
+                                  bold=False,
+                                  wrapWidth=32,
+                                  height=1,
+                                  pos=(0, 0),
+                                  anchorVert='center')
+                Q1_0 = vis.TextStim(win, text = message_dict['Q1_0_text'],
+                                    color='black', bold = False,\
+                                    wrapWidth = 32,\
+                                    height = 1,\
+                                    pos=(0,0),\
+                                    anchorVert = 'center')
+                Q2 = vis.TextStim(win,
+                                  text=message_dict['Q2_text'],
+                                  color='black',
+                                  bold=False,
+                                  wrapWidth=32,
+                                  height=1,
+                                  pos=(0, 0),
+                                  anchorVert='center')
+                Q2_0 = vis.TextStim(win,
+                                    text=message_dict['Q2_0_text'],
+                                    color='black',
+                                    bold=False,
+                                    wrapWidth=32,
+                                    height=1,
+                                    pos=(0, 0),
+                                    anchorVert='center')
+
+                wrong_answer = vis.TextStim(
+                    win,
+                    text=message_dict['wrong_answer_text'],
+                    height=.8,
+                    pos=(0, -5),
+                    color='red',
+                    bold=True)
+
+                question_time.draw()
+                win.flip()
+                Response(device=device,
+                         keyboard=keyboard,
+                         time_search=9000,
+                         allowed_keys=None,
+                         clock_items=clock_trial,
+                         row=rowI)
+
+                #Did you notice any regularities regarding the color of the target?
+                #Please press the top bottom for ‘yes’ and the bottom button for ‘no’
+                Q0.draw()
+                win.flip()
+                A0 = Response(device=device,
+                              keyboard=keyboard,
+                              time_search=9000,
+                              allowed_keys=None,
+                              clock_items=clock_trial,
+                              row=rowI)[0]
+
+                if A0 not in keys_4_answ_reduced:
+                    A0 = WrongAnswer(keyboard=keyboard,
+                                     question=Q0,
+                                     answer=A0,
+                                     warning=wrong_answer,
+                                     win=win,
+                                     device=device,
+                                     rowI=rowI,
+                                     keyss=keys_4_answ_reduced)
+
+                #Was the target often colored with one specific color throughout the whole experiment?
+                #Please press the top bottom for ‘yes’ and the bottom button for ‘no
+                Q1.draw()
+                win.flip()
+                A1 = Response(device=device,
+                              keyboard=keyboard,
+                              time_search=9000,
+                              allowed_keys=None,
+                              clock_items=clock_trial,
+                              row=rowI)[0]
+
+                if A1 not in keys_4_answ_reduced:
+                    A1 = WrongAnswer(keyboard=keyboard,
+                                     question=Q1,
+                                     answer=A1,
+                                     warning=wrong_answer,
+                                     win=win,
+                                     device=device,
+                                     rowI=rowI,
+                                     keyss=keys_4_answ_reduced)
+                A1_0 = None
+                if (keyboard and A1 == '1') or (
+                        A1 == 6 and
+                        not keyboard):  #Response on keyboard or cedrus is yes
+                    Q1_0.draw(
+                    )  #'Which color do you think the target was most often colored with?
+                    win.flip()
+                    A1_0 = Response(device=device,
+                                    keyboard=keyboard,
+                                    time_search=9000,
+                                    allowed_keys=None,
+                                    clock_items=clock_trial,
+                                    row=rowI)[0]
+                    if A1_0 not in keys_4_answ:
+                        A1_0 = WrongAnswer(keyboard=keyboard,
+                                           question=Q1_0,
+                                           answer=A1_0,
+                                           warning=wrong_answer,
+                                           win=win,
+                                           device=device,
+                                           rowI=rowI,
+                                           keyss=keys_4_answ)
+
+                Q2.draw(
+                )  # 'Did you notice that the most probable color of the target was changing during the experiment?
+                win.flip()
+                A2 = Response(device=device,
+                              keyboard=keyboard,
+                              time_search=9000,
+                              allowed_keys=None,
+                              clock_items=clock_trial,
+                              row=rowI)[0]
+                if A2 not in keys_4_answ_reduced:
+                    A2 = WrongAnswer(keyboard=keyboard,
+                                     question=Q2,
+                                     answer=A2,
+                                     warning=wrong_answer,
+                                     win=win,
+                                     device=device,
+                                     rowI=rowI,
+                                     keyss=keys_4_answ_reduced)
+
+                A2_0 = None
+                if (keyboard and A2 == '1') or (A2 == 6 and not keyboard):
+                    Q2_0.draw()
+                    win.flip()
+                    A2_0 = Response(device=device,
+                                    keyboard=keyboard,
+                                    time_search=9000,
+                                    allowed_keys=None,
+                                    clock_items=clock_trial,
+                                    row=rowI)[0]
+
+                    if A2_0 not in keys_4_answ:
+                        A2_0 = WrongAnswer(keyboard=keyboard,
+                                           question=Q2_0,
+                                           answer=A2_0,
+                                           warning=wrong_answer,
+                                           win=win,
+                                           device=device,
+                                           rowI=rowI,
+                                           keyss=keys_4_answ)
+
+#Adios amigo :)
+            bye.draw()
+            win.flip()
+            time.sleep(20)
+
+####################
+##     SAVING     ##
+####################
+
+# Save results on txt every row_save trials, in case of crash I have the data anyway
+
+    reaction_times = RTs_keyboard if keyboard else RTs_cedrus
+
+    if rowI % row_save == 0 and rowI != 0:
+
+        if not implicit:
+            sheet = np.column_stack(
+                (reaction_times, trial_time, items_time, placeholder_time,
+                 cue_time, is_response_right, response_key,
+                 df.loc[:, 'valid_trial'], df.loc[:, 'cue_identity_def'],
+                 df.loc[:, 'cue_validity_def'], df.loc[:, 'color_target'],
+                 df.loc[:, 'color_cue0'], df.loc[:, 'color_cue1'],
+                 df.loc[:, 'color_cue2']))
+        else:
+            sheet = np.column_stack(
+                (reaction_times, trial_time, items_time, is_response_right,
+                 response_key, df.loc[:, 'valid_trial'],
+                 df.loc[:, 'cue_identity_def'], df.loc[:, 'cue_validity_def'],
+                 df.loc[:, 'color_target']))
+
+        np.savetxt(file_name,
+                   sheet,
+                   delimiter=',',
+                   header=headers_answer,
+                   fmt='%s')
+
+if not practice:
+    total_time = total_clock.getTime()
+    info_file_final = open(
+        wdir + '\\data\\part_n_' + PN + '\\info_' + PN + '.txt', 'a')
+    info_file_final.write('total_time = ' + str(round(total_time / 60, 1)) +
+                          ' minutes')
+    info_file_final.write(
+        '\ntotal_time_without_break = ' +
+        str(round(total_time / 60, 1) -
+            (round(sum(breaks) / 60, 1))) + ' minutes')
+    info_file_final.write('\nTrials with break = ' + str(break_row))
+
+    if implicit:
+        info_file_final.write('\nA0 = ' + str(A0) + '\nA1 = ' + str(A1))
+        if A1_0 is not None:
+            info_file_final.write('\nA1_0 = ' + str(A1_0))
+            info_file_final.write('\nA2 = ' + str(A2))
+        if A2_0 is not None:
+            info_file_final.write('\nA2_0 = ' + str(A2_0))
+
+    info_file_final.close()
+    print('\n\nInfo file updated and written in txt!')
+
+#Write the number of the color and not the string label:
+come_back_color_func = lambda x: 0 if x == color_labels[0] else\
+                       (1 if x == color_labels[1] else 2)
+if not implicit:
+    for col in df.loc[:, 'color_target':'color_cue2']:
+        df.loc[:, col] = df.loc[:, col].apply(come_back_color_func)
+else:
+    df.loc[:, 'color_target'] = df.loc[:, 'color_target'].apply(
+        come_back_color_func)
+
+if not implicit:
+    sheet = np.column_stack(
+        (reaction_times, trial_time, items_time, placeholder_time, cue_time,
+         is_response_right, response_key, df.loc[:, 'valid_trial'],
+         df.loc[:, 'cue_identity_def'], df.loc[:, 'cue_validity_def'],
+         df.loc[:, 'color_target'], df.loc[:, 'color_cue0'],
+         df.loc[:, 'color_cue1'], df.loc[:, 'color_cue2']))
+else:
+    sheet = np.column_stack(
+        (reaction_times, trial_time, items_time, is_response_right,
+         response_key, df.loc[:, 'valid_trial'], df.loc[:, 'cue_identity_def'],
+         df.loc[:, 'cue_validity_def'], df.loc[:, 'color_target']))
+
+np.savetxt(file_name, sheet, delimiter=',', header=headers_answer, fmt='%s')
+
+if practice:
+    print(
+        'Reached the end of the practice succesfully!!\n\n Participant number is %s'
+        % PN)
+else:
+    if crash:
+        print('Reached the end of experiment with a crash at line %s' %
+              row_crash)
+    else:
+        print('\n\nReached the end of experiment succesfully!!')
+
+win.close()
+core.quit()

--- a/Init_Cshape_rev.py
+++ b/Init_Cshape_rev.py
@@ -1,0 +1,227 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Mon Oct 14 12:18:29 2019
+
+@author: Jacopo
+
+Sets important variables once, for Randomization and experimental script.
+Sets implicit or explicit mode, practice or real experiment, language,
+response device and participant numbers.
+Plus other parameters among which turn on/off some control on randomizations,
+possibility to quit the experiment with 'q' or 'esc', monitors...etc
+"""
+
+import random
+import shutil
+import os
+import time
+
+from psychopy import monitors
+
+if __name__ != '__main__':
+    print('Init script imported...\n')
+
+#Practice or real data_frame/experiment?
+practice = False
+
+## Implicit mode?
+implicit = True
+
+##Language
+dutch = False
+
+## Possible to quit experiment? Must be set to False in real experiment
+quiT = True
+
+# Response device: keyboard or Cedrus?
+keyboard = True
+
+monitor = 'jac'  #set 'exp' for experiment, 'jac' for my latitude, else 'default'
+
+# Set your working directory (where the scripts are, and where the data is saved)
+# wdir = os.getcwd()
+wdir = 'C:\\Users\\Jacopo\\OneDrive - Universita degli Studi di Milano-Bicocca\
+\\Personal\\Documents\\Universitá\\Psicologia\\AEPS\\Python\\PsychoPy\\Yapf_reformatted'
+
+# Saving txt after how many trials?
+row_save = 15
+
+# After how many minutes should we do a break?
+break_time = 7  #7 was default
+
+# Creates a dataframe for each participant number
+participants = [2]
+
+## Randomization controls?
+row_check = 15
+
+if not implicit:
+    control_target_cue_match = False  #see Randomization script, needs improvement
+    control_same_color = True  #If False, it is possible to have three cues of the same color.
+
+# Set the preferred color space, adjust the labels accordingly.
+#To use gammacorrection and isoluminant stimuli, RGB is needed.
+#To test on different monitors use HSV.
+
+color_space = 'hsv'
+
+if color_space == 'hsv':
+    color_labels = [(240, 1, 1), (0, 1, 1), (90, 1, 1)]
+elif color_space == 'rgb':
+    color_labels = [
+        (-1, -1, 1), (-1 + (255 * 9.6 / 26 * (2 / 255)), -1, -1),
+        (-1, -1 + (255 * 9.6 / 79.9 * (2 / 255)), -1)
+    ]  #we could use colorspace rgb255 to avoid messing with the ones..
+else:
+    color_labels = ['blue', 'red', 'green']  # 0, 1, 2
+
+##Hints (debug and general idea of the procedure)?
+if not implicit:
+    if not practice:
+        hints = False
+    else:
+        hints = True
+
+## CRASH? Edit the line to start again from there in the dataframe
+# Need to rename the response dataframe and the info file!!
+crash = False
+if crash:
+    row_crash = 45
+else:
+    row_crash = 0
+
+orientation_target = [0, 1]  #[90,270] # Only turned down/up
+orientation_distractor = [0, 1]  #[0,180] # Only turned right/left
+
+cue_validity_0 = .76
+cue_validity_1 = .83
+cue_validity_2 = .9
+
+#One serie is a set of trials in which cue_identity and cue_validity do NOT change
+series = 1 if practice else 9  # Number of series in total
+trials_total = 630  #Number of rows in the dataframe
+if practice:
+    trials_total = 12 if implicit else 30
+
+number_positions = 12  # Search array items
+number_distractors = number_positions - 1
+
+colors = [0, 1, 2]  #['blue','red', 'green']
+
+if keyboard:
+    KeyResp = ['down', 'up']
+    esc_keys = ['q', 'escape']
+    allowed_keys = KeyResp + esc_keys + ['space']
+    headers_answer = 'Reaction_times_Keyboard,Total_trial_time,Items_time,Placeholder_time,Cue_time,is_response_right,response_key,valid_trial, cue_identity, cue_validity,\
+    color_target, color_cue0, color_cue1, color_cue2'
+
+    if implicit:
+        headers_answer = 'Reaction_times_Keyboard,Total_trial_time,Items_time,is_response_right,response_key,valid_trial, cue_identity, cue_validity,\
+    color_target'
+
+else:
+    KeyResp = [0, 6]  #buttons of the cedrus box for response
+    allowed_keys = None
+    esc_keys = [3]  #central button of the cedrus
+    headers_answer = 'Reaction_times_Cedrus,Total_trial_time,Items_time,Placeholder_time,Cue_time,\
+    is_response_right,Button_pressed,response_key, valid_trial, cue_identity, cue_validity,\
+    color_target, color_cue0, color_cue1, color_cue2'
+
+    if implicit:
+        headers_answer = 'Reaction_times_Cedrus,Total_trial_time,Items_time,\
+    is_response_right,Button_pressed,response_key, valid_trial, cue_identity, cue_validity,\
+    color_target'
+
+headers = [
+    'position_target', 'color_target', 'color_cue0', 'color_cue1',
+    'color_cue2', 'ori_target', 'ori_distractor_0', 'ori_distractor_1',
+    'ori_distractor_2', 'ori_distractor_3', 'ori_distractor_4',
+    'ori_distractor_5', 'ori_distractor_6', 'ori_distractor_7',
+    'ori_distractor_8', 'ori_distractor_9', 'ori_distractor_10',
+    'ori_distractor_11', 'cue_identity_def', 'cue_validity_def', 'valid_trial',
+    'correct_response', 'Start_position'
+]
+if implicit:
+    headers = headers[:2] + headers[5:]
+
+refresh_rate = 60  # in Hertz
+
+
+def ms_to_frames(ms, rate=refresh_rate):
+    return round(ms * rate / 1000)
+
+
+if practice:
+    time_placeholder = range(ms_to_frames(500))
+    time_cues = range(ms_to_frames(5000))
+    time_fixation = range(
+        random.randrange(ms_to_frames(500), ms_to_frames(1000),
+                         ms_to_frames(100))
+    )  # Random variable must be called everytime inside the script..?
+    time_search = 8
+    time_iti = range(
+        random.randrange(ms_to_frames(500), ms_to_frames(1000),
+                         ms_to_frames(100))
+    )  # Random variable must be called everytime inside the script..?
+else:
+    time_placeholder = range(ms_to_frames(500))
+    time_cues = range(ms_to_frames(800))
+    time_fixation = range(
+        random.randrange(ms_to_frames(500), ms_to_frames(1000),
+                         ms_to_frames(100))
+    )  # Random variable must be called everytime inside the script..?
+    time_search = 2.5
+    time_iti = range(
+        random.randrange(ms_to_frames(500), ms_to_frames(1000),
+                         ms_to_frames(100))
+    )  # Random variable must be called everytime inside the script..?
+
+if implicit:
+    fix_max = 2300
+    fix_min = 1800
+    time_search = 2.5
+else:
+    fix_max = 1000
+    fix_min = 500
+
+#Inter-trial-interval
+iti_max = 1000
+iti_min = 500
+
+if implicit:
+    # Top button for CEDRUS is 6-----> 6 == YES
+    keys_4_answ = ['1', '2', '3'] if keyboard else [0, 3, 6]
+    keys_4_answ_reduced = ['1', '3'] if keyboard else [0, 6]
+
+    ### MONITORS.. I can try to laod the json calibration here C:\Users\pp02\AppData\Roaming\psychopy3\monitors
+    # Putting the gamma calibration file in the working directory will upload it to the right place in the computer.
+
+gamma_path = 'C:\\Users\\pp02\\AppData\\Roaming\\psychopy3\\monitors\\'
+gamma_configuration_name = 'BenQ.json'
+if monitor == 'default':
+    mon = monitors.Monitor('testMonitor')
+elif monitor == 'exp':
+    if os.path.isfile(os.path.join(
+            os.getcwd(), 'BenQ.json')) and not os.path.isfile(
+                os.path.normpath(
+                    os.path.join(gamma_path, gamma_configuration_name))):
+        print(
+            'Gamma configuration file found! Will move it in the right place\n'
+        )
+        shutil.copy(os.path.join(os.getcwd(), gamma_configuration_name),
+                    os.path.normpath(gamma_path))
+    elif not os.path.isfile(os.path.join(os.getcwd(),
+                                         gamma_configuration_name)):
+        print('Gamma configuration file not found!\n')
+    elif os.path.isfile(
+            os.path.normpath(os.path.join(gamma_path,
+                                          gamma_configuration_name))):
+        print('Gamma configuration file already present!\n\n')
+    time.sleep(2)
+    mon = monitors.Monitor(name='BenQ', width=53.1, distance=60)
+    mon.setSizePix([1920, 1080])
+    mon.setCurrent('2019_10_30 16:27_gamma')
+elif monitor == 'jac':
+    mon = monitors.Monitor('Latitude_Jacopo')
+else:
+    raise Exception('Monitor name not set correctly!!')

--- a/Messages.py
+++ b/Messages.py
@@ -1,0 +1,231 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Apr  1 14:22:04 2020
+
+@author: Jacopo
+"""
+
+from Init_Cshape_rev import dutch, keyboard, implicit
+
+### MESSAGES and translation: creates a dictionary with all needed messages
+### 3 main parameters for difference in messages: task (implicit/explicit),
+### language and device(keyboards vs cedrus)
+
+message_dict = dict()
+
+if keyboard:
+    wrong_key_text = 'Wrong button, please only respond with up or down arrow' if not dutch else\
+    'Verkeerde knop, reageer alsjeblieft alleen met de bovenste of de onderste toets'
+    buttoN = 'the spacebar' if not dutch else 'de spatiebalk'
+
+else:
+    wrong_key_text = 'Wrong button, please only respond with the first and last button' if not dutch else\
+    'Verkeerde knop, reageer alsjeblieft alleen met de bovenste of de onderste toets'
+    buttoN = 'a button' if not dutch else 'de responsknop'
+
+if not implicit:  #EXPLICIT TASK
+    switch_text = 'The position of the predictive cue is about to change!' if not dutch else 'De positie van de voorspellende cue gaat bijna veranderen!'
+    no_more_mess_text = 'No more hints! Can you follow the right cue?' if not dutch else 'Geen hints meer! Kun je de juiste cue volgen?'
+    hint_text = 'The reliable cue is in the {} position' if not dutch else 'De betrouwbare cue staat in de {} positie'
+    important_message_remember = 'Always try to understand which of the three cues is the reliable one (more often colored as the target) and use it to find the target faster!\n\n\
+     And remember that:\
+    \n\n\n - The reliable cue will not *always* be of the same color of the target, but *most of the times* it will!\
+    \n\n\n - The reliable cue can change position after a certain amount of trials' if not dutch else\
+    'Probeer te begrijpen welke van de drie signalen de betrouwbare is (vaker gekleurd als het doelwit) en gebruik het om\
+ het doel sneller te vinden!\n\n\
+     En onthoud dat:\
+    \n\n\n - De betrouwbare cue zal niet *altijd* van dezelfde kleur zijn als het doelwit, maar *meestal* wel!\
+    \n\n\n - De betrouwbare cue zal van positie veranderen na een variabel aantal trials.'
+
+    invalid_hint = 'This trial was invalid! The reliable cue was not of the same color of the target, but this doesn\'t necessarly mean\
+ that it switched position!' if not dutch else\
+    'Deze trial was ongeldig! De betrouwbare cue was niet van dezelfde kleur als het doelwit, \
+ maar dit betekent niet noodzakelijkerwijs dat het van plaats veranderd is!'
+
+    end_practice = 'Good job! As you may have noticed, very often but not always the reliable cue has the same \
+color of the target!\n\nIn the real experiment you will have no hints and you will need to infer when the reliable\
+ cue has changed position to make a good performance :)' if not dutch else 'Goed zo! Zoals je misschien gemerkt hebt heeft de\
+ betrouwbare cue vaak, maar niet altijd, dezelfde kleur als de target! In het echte experiment heb je geen hints en moet je raden\
+ wanneer de betrouwbare cue van positie is veranderd om een goede prestatie te leveren :)'
+
+    message_2_target = 'Please look at the fixation point in the center of the screen and start your search from there!\nThe target will be always present and you have to respond to its orientation in this way:\
+    \n\n- Press the button on the top with your {} index finger if the gap is on the top of the shape.\
+    \n- Press the button on the bottom with your {} index finger if the gap is on the bottom of the shape.' if not dutch else\
+    'Kijk naar het fixatiekruis in het midden van het scherm tot de stimuli op het scherm verschijnen, begin dan onmiddellijk met zoeken!\
+ Er zal altijd een target aanwezig zijn en je moet reageren op de oriëntatie van deze target:\
+    \n\n- Duw met je {} wijsvinger op de bovenste toets als de opening aan de bovenkant is.\
+    \n- Duw met je {} wijsvinger op de onderste toets als de opening aan de onderkant is.'
+
+
+    message_3_cues = 'Before the search, a set of 3 colored cues will appear (colors will change every trial). Please note that:\
+    \n\n- Only ONE of the 3 cues will often have the same color of the target, helping you in the visual search!\
+    \n\n- The other 2 cues will be colored randomly.' if not dutch else\
+    'Voor de zoektaak begint zal een set van 3 gekleurde cues verschijnen (kleuren veranderen van trial tot trial). Let op dat:\
+    \n\n\n- Enkel ÉÉN van de 3 cues een correct voorspellende cue is, en enkel deze cue heeft hetzelfde kleur als de target. Dit kan je helpen in de visuele zoektaak.\
+    \n\n- De andere 2 cues zullen een willekeurige kleur hebben.'
+
+
+    message_objective = '**You also have to guess which of the three cues is the one that is OFTEN colored as the target in order to make a quick detection!**'if not dutch else\
+    '**Je zal moeten raden welk van de 3 cues de correct voorspellende cue is. Dus, welke cue VAAK hetzelfde kleur heeft als de target om zo de target snel te kunnen detecteren.**'
+
+    message_4_switch = 'The cue often colored as the target will not remain the same for the whole experiment (for example, it can switch \
+from the right position to the top one after some trials). Generally, this cue change will happen a few times within the experiment (but note that it won\'t change too often - NOT every few trials...' if not dutch else\
+    'Welke cue vaak dezelfde kleur heeft als de target, zal niet gedurende het hele experiment hetzelfde blijven (het kan bijvoorbeeld na \
+ enkele trials veranderen van de rechter positie naar de bovenste positie). Over het algemeen zal deze cue verandering een paar\
+ keer binnen elk blok gebeuren (maar let op: het zal niet te vaak veranderen).'
+
+
+    recap_message = 'Just a few things before we get started:\n\n\n\
+    - Remember to use the reliable cue to speed up the visual search (respond as fast and as accurately as possible)\n\n\
+    - Try to notice if the cue you are using is reliable or not\n\n\
+    - Always look at the fixation cross in the center before the search!' if not dutch else\
+    'Een paar dingen voordat we beginnen:\n\n\n\
+    - Vergeet niet de betrouwbare cue te gebruiken om het visueel zoeken te versnellen (reageer zo snel en zo accuraat mogelijk).\n\n\
+    - Probeer op te merken of de cue die je gebruikt betrouwbaar is of niet.\n\n\
+    - Kijk altijd naar het fixatiekruis in het midden voor het zoeken!'
+
+    message_dict.update(switch_text=switch_text,
+                        no_more_mess_text=no_more_mess_text,
+                        hint_text=hint_text,
+                        important_message_remember=important_message_remember,
+                        invalid_hint=invalid_hint,
+                        message_3_cues=message_3_cues,
+                        message_objective=message_objective,
+                        message_4_switch=message_4_switch)
+
+else:  #IMPLICIT TASK
+    message_2_target = 'Please look at the fixation point in the center of the screen and start your search from there!\nThe\
+ target will be always present and you have to respond to its orientation in this way:\
+    \n\n\n- Press the button on the top with your {} index finger if the gap is on the top of the shape.\
+    \n\n- Press the button on the bottom with your {} index finger if the gap is on the bottom of the shape.' if not dutch else\
+    'Kijk naar het fixatiekruis in het midden van het scherm tot de stimuli op het scherm verschijnen, begin dan onmiddellijk met zoeken!\
+ Er zal altijd een target aanwezig zijn en je moet reageren op de oriëntatie van deze target:\
+    \n\n- Duw met je {} wijsvinger op de bovenste toets als de opening aan de bovenkant is.\
+    \n\n- Duw met je {} wijsvinger op de onderste toets als de opening aan de onderkant is.'
+
+    recap_message = 'Just a few things before we get started:\n\n\n\
+    \n\n- Press the button on the top with your {} index finger if the gap is on the top of the shape.\
+    \n- Press the button on the bottom with your {} index finger if the gap is on the bottom of the shape.\
+    \n- Always look at the fixation cross in the center before the search!' if not dutch else\
+    'Een paar dingen voordat we beginnen:\n\
+    \n\n- Duw met je {} wijsvinger op de bovenste toets als de opening aan de bovenkant is.\
+    \n\n- Duw met je {} wijsvinger op de onderste toets als de opening aan de onderkant is.\
+    \n\n- Kijk altijd naar het fixatiekruis in het midden voor het zoeken!'
+
+    end_practice = 'Good job!' if not dutch else 'Goed zo!'
+
+    questions_text = 'The task is over! Please answer a few questions about the color of the target :)' if not dutch else\
+    'De taak is voorbij! Beantwoord a.u.b. een paar vragen over de kleur van het doelwit :)'
+
+    Q0_text = 'Did you notice any regularities regarding the color of the target? Please press the top button for ‘yes’ and the bottom button for ‘no’'\
+    if not dutch else 'Heeft u enige regelmatigheden opgemerkt met betrekking tot de kleur van het doelwit?\
+ Druk op de bovenste knop voor \'ja\' en de onderste knop voor \'nee\''
+
+    Q1_text = 'Was the target often colored with one specific color throughout the whole experiment? Please press the top button for ‘yes’ and the bottom button for ‘no’'\
+    if not dutch else 'Was het doelwit vaak één specifieke kleur gedurende het hele experiment?\
+ Druk op de bovenste knop voor ’ja’ en de onderste knop voor ’nee’'
+
+    Q1_0_text = 'Which color do you think the target was most often colored with? Please press the top button for ‘red’, the middle button for ‘blue’ and the bottom button for ‘green’'\
+    if not dutch else 'Welke kleur denk je dat het doelwit het meest gekleurd was? Druk op de bovenste knop voor ’rood’,\
+ de middelste knop voor ’blauw’ en de onderste knop voor ’groen’'
+
+    Q2_text = 'Did you notice that the most probable color of the target was changing during the experiment\
+ (for example, in one part it was blue, and then red, and then green)? Press the top button for ‘yes’ and the bottom button for ‘no’' if not dutch else\
+ 'Merkte je dat de meest waarschijnlijke kleur van het doelwit tijdens het experiment veranderde\
+ (bijvoorbeeld, in één deel was het blauw, en dan rood, en dan groen)?\
+ Druk op de bovenste knop voor ’ja’ en de onderste knop voor ’nee’'
+
+    Q2_0_text = 'How many times do you think the most probable color of the target has changed throughout the experiment? Please press the top button\
+ if you think it changed around 3 times, the middle button if it changed around 8 times and the top button if it changed around 13'\
+    if not dutch else 'Hoe vaak denk je dat de meest waarschijnlijke kleur van het doelwit tijdens het experiment is veranderd?\
+ Druk op de bovenste knop als u denkt dat de kleur ongeveer 4 keer is veranderd, de middelste knop als deze ongeveer 9 keer is veranderd en de bovenste knop als deze ongeveer 14 keer is veranderd.'
+
+    wrong_answer_text = 'Wrong button, please only respond with the indicated buttons' if not dutch else\
+    'Verkeerde knop, reageer alleen met de aangegeven knoppen.'
+
+    keys_4_answ = ['1', '2', '3'] if keyboard else [
+        0, 3, 6
+    ]  # Top button for CEDRUS is 6-----> 6 == YES
+    keys_4_answ_reduced = ['1', '3'] if keyboard else [0, 6]
+
+    message_dict.update(questions_text=questions_text,
+                        Q0_text=Q0_text,
+                        Q1_text=Q1_text,
+                        Q1_0_text=Q1_0_text,
+                        Q2_text=Q2_text,
+                        Q2_0_text=Q2_0_text,
+                        wrong_answer_text=wrong_answer_text,
+                        keys_4_answ=keys_4_answ,
+                        keys_4_answ_reduced=keys_4_answ_reduced)
+
+space = 'Press {} to continue...' if not dutch else 'druk op {} om verder te gaan...'
+
+message_1_welcome = 'Welcome to the experiment, {0}! In this visual search task, you are asked to detect as quickly\
+ and accurately as possible one target among distractors.\n\nAll the items are shapes of 3 different random colors (red, blue or green - changing randomly),\
+ with a gap on one side:\
+\n\n- Target items have a gap on either the upper or the lower part.\
+\n- Distractors have a gap on the left or on the right.' if not dutch else\
+'Welkom in dit experiment, {0}! In deze visuele zoektaak zal je zo snel\
+ en accuraat mogelijk een target moeten detecteren tussen distractoren (afleiders). Deze stimuli zijn vormen in 3 verschillende kleuren (rood, blauw of groen) met een opening aan één kant:\
+\n\n- Target stimuli hebben ofwel aan de bovenkant ofwel aan de onderkant een opening\
+\n- Distractoren hebben ofwel aan de linkerkant ofwel aan de rechterkant een opening.'
+
+message_2_target = 'Please look at the fixation point in the center of the screen and start your search from there!\nThe\
+ target will be always present and you have to respond to its orientation in this way:\
+\n\n\n- Press the button on the top with your {} index finger if the gap is on the top of the shape.\
+\n\n- Press the button on the bottom with your {} index finger if the gap is on the bottom of the shape.' if not dutch else\
+'Kijk naar het fixatiekruis in het midden van het scherm tot de stimuli op het scherm verschijnen, begin dan onmiddellijk met zoeken!\
+ Er zal altijd een target aanwezig zijn en je moet reageren op de oriëntatie van deze target:\
+\n\n- Duw met je {} wijsvinger op de bovenste toets als de opening aan de bovenkant is.\
+\n\n- Duw met je {} wijsvinger op de onderste toets als de opening aan de onderkant is.'
+
+message_5_questions = 'Please ask any question now if something is not clear!' if not dutch else\
+'Is alles duidelijk? Zo niet, stel alsjeblieft vragen aan de proefleider!'
+
+message_6 = 'You will start with some practice trials as soon as you press a button..' if not dutch else\
+'Druk op een knop om te beginnen met enkele oefentrials.'
+
+message_final = 'Press a button whenever you are ready to start the real experiment, {}!' if not dutch else\
+'Druk op een knop wanneer je klaar bent om het echte experiment te starten, {}!'
+
+resp_to_continue = 'Respond correctly to these targets to continue!' if not dutch else\
+                   'Reageer correct op deze target stimuli om door te gaan!'
+
+test1 = 'Press {} and respond correctly to these targets to continue!' if not dutch else\
+'Druk op {} en reageer correct op deze target stimuli om door te gaan!'
+
+late_answer_text = 'Try to respond faster!' if not dutch else 'Probeer om sneller te reageren!'
+
+neg_feedback_text = 'Wrong answer! Up for gap in the top, down for gap in the bottom!' if not dutch else 'Verkeerd antwoord!\
+ Gebruik de bovenste toets als de opening aan de bovenkant is, en de onderste toets als de opening aan de onderkant is.'
+
+pos_feedback_1 = 'Right! But you can be faster than this!' if not dutch else 'Correct! Maar je kunt sneller zijn dan dit!'
+pos_feedback_2 = 'Right! But you won\'t have all this time in the real experiment!' if not dutch else 'Correct! Maar je zal niet zoveel tijd hebben in het echte experiment!'
+pos_feedback_3 = 'Right! Pretty quick..can you go faster?' if not dutch else 'Correct! Redelijk snel...kun je nog sneller reageren?'
+pos_feedback_4 = 'Right! Nice reaction time..try to lower it even further!' if not dutch else 'Correct! Goede reactietijd...probeer nog sneller te reageren!'
+pos_feedback_5 = 'Right! Very fast!' if not dutch else 'Correct! Heel snel!'
+pos_feedback_6 = 'Right! Impressively fast!!!' if not dutch else 'Correct! Indrukwekkend snel!!'
+
+bye_text = 'Thanks for participating and goodbye!' if not dutch else 'Bedankt voor uw deelname en tot ziens.'
+
+message_dict.update(wrong_key_text=wrong_key_text,
+                    recap_message=recap_message,
+                    end_practice=end_practice,
+                    buttoN=buttoN,
+                    space=space,
+                    message_1_welcome=message_1_welcome,
+                    message_2_target=message_2_target,
+                    message_5_questions=message_5_questions,
+                    message_6=message_6,
+                    message_final=message_final,
+                    resp_to_continue=resp_to_continue,
+                    test1=test1,
+                    late_answer_text=late_answer_text,
+                    neg_feedback_text=neg_feedback_text,
+                    pos_feedback_1=pos_feedback_1,
+                    pos_feedback_2=pos_feedback_2,
+                    pos_feedback_3=pos_feedback_3,
+                    pos_feedback_4=pos_feedback_4,
+                    pos_feedback_5=pos_feedback_5,
+                    pos_feedback_6=pos_feedback_6,
+                    bye_text=bye_text)

--- a/Randomization_rev.py
+++ b/Randomization_rev.py
@@ -1,0 +1,486 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Oct 2 15:11:32 2019
+
+@author: Jacopo
+
+This script creates as many dataframes as participants set in the init script,
+randomizing the position, color, and orientation of the items.
+"""
+
+import math
+import os
+import time
+import numpy as np
+import pandas as pd
+
+from Init_Cshape_rev import (trials_total, series, number_positions, colors,
+                              orientation_target, orientation_distractor,
+                              cue_validity_0, cue_validity_1, cue_validity_2,
+                              headers, keyboard, row_check, practice, KeyResp,
+                              participants, implicit, wdir)
+
+if not implicit:
+    from Init_Cshape_rev import (control_target_cue_match, control_same_color)
+
+if not os.path.isdir(wdir + '\\data'):
+    os.mkdir(wdir + '\\data')
+    print('created data directory in %s' % wdir)
+
+########################
+##     PARAMETERS     ##
+########################
+
+if keyboard:
+    device_n = 'keyboard'
+else:
+    device_n = 'Cedrus box'
+
+if not implicit:
+    if control_target_cue_match:
+        if control_same_color:
+            contr = ', controlling for three cues of the same color and cue/target matches every %s rows' % row_check
+        else:
+            contr = ', controlling only for cue/target matches every %s rows (there will be three cues of the same color)' % row_check
+    else:
+        if control_same_color:
+            contr = ', controlling for three cues of the same color and with pure randomization for the distractor cues.'
+        else:
+            contr = ' with pure randomization for the distractor cues.'
+
+string = 'Starting...going to build %s dataframes' % (str(len(participants)))\
+        + (' for practice' if practice else '')\
+        + (contr if not implicit else '')\
+        + '\nThe device is %s and the mode is %s' % \
+            (device_n, 'implicit\n' if implicit else 'explicit\n')
+
+print(string)
+
+time.sleep(2.5)
+
+############################
+##     INITIALIZATION     ##
+############################
+
+position_target = np.zeros(trials_total, dtype=int)
+start_position = np.zeros(trials_total, dtype=int)
+color_target = np.zeros(trials_total, dtype=int)
+ori_target = np.zeros(trials_total, dtype=int)
+correct_response = np.zeros(trials_total, dtype=int)
+if keyboard:
+    correct_response = ['na'] * trials_total
+cue_identity_def = np.zeros(trials_total, dtype=int)
+cue_validity_def = np.zeros(trials_total, dtype=float)
+valid_trial = np.zeros(trials_total, dtype=int)
+guessed_cues = np.zeros(trials_total, dtype=int)
+ori_distractor = np.random.choice(orientation_distractor,
+                                  number_positions * trials_total)
+if not implicit:
+    color_cue0 = np.zeros(trials_total, dtype=int)
+    color_cue1 = np.zeros(trials_total, dtype=int)
+    color_cue2 = np.zeros(trials_total, dtype=int)
+    valid_cue0_def = np.zeros(trials_total, dtype=int)
+    valid_cue1_def = np.zeros(trials_total, dtype=int)
+    valid_cue2_def = np.zeros(trials_total, dtype=int)
+
+###########################
+##     RANDOMIZATION     ##
+###########################
+
+# For cycle for creating as many dataframes as participants
+for part_num in participants:
+
+    if not os.path.isdir(wdir + '\\data\\part_n_' + str(part_num)):
+        os.mkdir(wdir + '\\data\\part_n_' + str(part_num))
+
+    if practice:
+        df_name = wdir + '\\data\\part_n_' + str(part_num) + '\\Practice_' + (
+            'implicit_' if implicit else '') + str(part_num) + '.csv'
+    else:
+        df_name = wdir + '\\data\\part_n_' + str(part_num) + '\\Dataframe_' + (
+            'implicit_' if implicit else '') + str(part_num) + '.csv'
+
+    if os.path.isfile(df_name):
+        iN = input(
+            'The dataframe number %s already exists! Press \'y\' to delete it and proceed or \'n\' to cancel (\
+ if on Psychopy just stop the script and delete the file because input seems bugged):\n'
+            % part_num)
+        while not iN in ('y', 'n'):
+            iN = input('Please answer \'y\' or \'n\':')
+        if iN == 'n':
+            raise Exception('CANCELLED')
+        os.remove(df_name)
+        print('\n\nErased %s and proceeding\n\n' % df_name)
+
+    ### Take care that since lambda is .0125 mean of exp distribution is 80: series and total_trials
+#   should be comparable (trials_total%series should not be too high!!), if not the while check for
+#   number of trials will go on infinitely.
+
+    if practice:
+        cue_switches = np.array(
+            [11])  #the identity switch happens in this line during practice
+    else:
+        tot_trials_check = True
+        exp_mean = 70
+        lambd = 1 / exp_mean
+        #Exponential function copied from Anna's script.
+        #Determines the lenght of each series
+        while tot_trials_check:
+            series_lenght = np.arange(series)
+            for switch_ind in series_lenght:
+                x = np.random.rand()  #number of random sample
+                #inverse transform
+                A = math.exp(-40 * lambd) - math.exp(-100 * lambd)
+                y = -math.log(math.exp(-40 * lambd) - x * A) / lambd
+                series_lenght[switch_ind] = y
+
+            if sum(series_lenght) == (trials_total):
+                tot_trials_check = False
+
+        # Array with the trial number in which the switch happens.
+        cue_switches = np.delete(np.cumsum(series_lenght), [series - 1])
+
+    if practice:
+        cue_validity_all = [.9, .8]
+        cue_identity = np.array([0, 1], dtype=int)
+    else:
+        cue_validity_all = [cue_validity_0, cue_validity_1, cue_validity_2]
+        cue_identity = [0, 1, 2]
+
+        # Set all the possible cue identity and cue validity crossing, and shuffle
+        arr = []
+        for el in cue_validity_all:
+            for element in cue_identity:
+                arr.append((el, element))
+
+        arr = np.array(arr)
+        np.random.shuffle(arr)
+        while 0 in np.diff(arr[:, 1]):
+            np.random.shuffle(arr)
+
+        cue_validity_all = arr[:, 0]
+        cue_identity = np.array(arr[:, 1], dtype=int)
+
+    # For cycle for all the trials - create each row in the dataframe
+    for rowI in range(trials_total):
+
+        # Set cue_identity and cue validity, indexing based on how many trials have already been done. Basically changes
+        # cue identity and validity when the row corresponds to the switch.
+        part = sum(rowI > cue_switches)
+        cue_validity_def[rowI] = cue_validity_all[part]
+        cue_identity_def[rowI] = cue_identity[part]
+
+        # Set a random position and orientation for the target, set the position in which the drawing starts.
+        position_target[rowI] = np.random.choice(number_positions)
+        start_position[rowI] = np.random.choice(number_positions)
+        ori_target[rowI] = np.random.choice(orientation_target)
+        # Set which is the correct answer based on target orientation.
+        # CEDRUS BOX response
+        if not keyboard:
+            if ori_target[rowI] == 0:  #Gap in the bottom
+                correct_response[rowI] = KeyResp[0]  #Cedrus button on the left
+            else:  #Gap in the top
+                correct_response[rowI] = KeyResp[
+                    1]  #Cedrus button on the right
+
+        # KEYBOARD response
+        else:
+            if ori_target[rowI] == 0:
+                correct_response[rowI] = 0  #down
+            else:
+                correct_response[rowI] = 1  # up
+
+        # Number of positions (12) must be perfectly divisible by the number of colors (3)
+        if number_positions % len(colors) == 0:
+            alfa = int(number_positions / len(colors))
+
+        # Set the weights for the weighted sample of cue colors.
+        # First set the weights for the non predictive colors
+        weights_distractors = [(1 - cue_validity_def[rowI]) /
+                               (len(colors) - 1)] * (len(colors) - 1)
+
+        # Now append the cue_validity to the other colors' weight
+        if not implicit:
+            weight_predictive_cue = np.append(weights_distractors,
+                                              cue_validity_def[rowI])
+            color_target[rowI] = np.random.choice(colors)
+        else:
+            final_weights = np.insert(weights_distractors,
+                                      cue_identity_def[rowI],
+                                      cue_validity_def[rowI])
+            color_target[rowI] = np.random.choice(colors, p=final_weights)
+
+        if not implicit:
+            # Adjust(roll) the weights array(which is already right for color_target == 2).
+            # If color target == 0, roll weight array of 1 position right
+            for roll in range(len(colors) - 1):
+                if color_target[rowI] == roll:
+                    weight_predictive_cue = np.roll(weight_predictive_cue,
+                                                    roll + 1)
+
+            # Set color of cues, the distractor ones at random, the predictive one with weighted sample.
+            color_cues = np.random.choice(colors, size=3, replace=True)
+            color_cues[cue_identity_def[rowI]] = np.random.choice(
+                colors, p=weight_predictive_cue)
+
+            #Control for 3 cues of the same color (only if control is True):
+            if control_same_color:
+                while color_cues[0] == color_cues[1] == color_cues[2]:
+                    color_cues = np.random.choice(colors, size=3, replace=True)
+                    color_cues[cue_identity_def[rowI]] = np.random.choice(
+                        colors, p=weight_predictive_cue)
+
+            color_cue0[rowI] = color_cues[0]
+            color_cue1[rowI] = color_cues[1]
+            color_cue2[rowI] = color_cues[2]
+
+        # Determine if the trial is valid or not
+
+        valid_trial[rowI] = 0
+        if not implicit:
+            if color_target[rowI] == color_cues[cue_identity_def[rowI]]:
+                valid_trial[rowI] = 1
+        elif color_target[rowI] == cue_identity_def[rowI]:
+            valid_trial[rowI] = 1
+
+    # Put every randomized array in a matrix
+    objs = (position_target,
+            color_target,
+            color_cue0,
+            color_cue1,
+            color_cue2,
+            ori_target,
+            ori_distractor.reshape((number_positions, trials_total)),
+            cue_identity_def,
+            cue_validity_def,
+            valid_trial,
+            correct_response,
+            start_position) if not implicit else\
+            (position_target,
+             color_target,
+             ori_target,
+             ori_distractor.reshape((number_positions, trials_total)),
+             cue_identity_def,
+             cue_validity_def,
+             valid_trial,
+             correct_response,
+             start_position)
+
+    matrix = np.transpose(np.vstack(objs))
+
+    #######################################
+    ##     CONTROL CUE RANDOMIZATION     ##
+    #######################################
+
+    #Not used in real experiment. Code should be rewritten and probabilities calculated
+    #accurately after the control is active
+
+    if not implicit:
+        if control_target_cue_match:
+
+            full_series = np.append(
+                cue_switches, trials_total
+            )  # Get the full array of switches and add the final trial
+
+            # For cycle to go through each series/block of cue identity\cue validity
+            for start_row, id_I in zip(full_series, range(len(full_series))):
+
+                # Create an array with the adjusted chunk, considering that the rows in a series may not be exactly dividible by [row_check]:
+                # So, repeat row_check as many times as possible inside the rows in a series and then add the remainder as last item. EG: if 96 rows and row_check = 10:
+                # repeat 10 nine times and append 6: [10,10,10,10,10,10,10,10,10,6]
+
+                temp_serie = np.arange(start_row)
+                # Adjust if we are after the first cycle
+                if id_I != 0:
+                    temp_serie = np.arange(full_series[id_I - 1], start_row)
+
+                # Know the remainder to decide how to split the array
+                remainder = len(temp_serie) % row_check
+
+                # if remainder is more than half of the rows I want to check for, split the array one more time
+                if remainder > row_check / 2:
+                    real_row_check = np.array_split(
+                        temp_serie,
+                        indices_or_sections=int(len(temp_serie) / row_check) +
+                        1)
+                else:
+                    real_row_check = np.array_split(
+                        temp_serie,
+                        indices_or_sections=int(len(temp_serie) / row_check))
+
+                # Distractor indexing: choose which are the distractors based on the cue identity (if cue_identity is 1, distractors are [0,1,2] without the 1).
+                # Add 2 to match the columns in the matrix and index the real distractors..this is risky because I can mess with the columns indexes
+                distr_ind = np.array(
+                    [x for x in [0, 1, 2] if x != cue_identity[id_I]]) + 2
+
+                # Inside each series/block, go through each array resulting from the split
+                for chunk in real_row_check:
+
+                    # Shuffle the indexing so that rows are randomly accessed
+                    np.random.shuffle(chunk)
+
+                    # If color check is not active, we will break the while loop. The things inside the while are
+                    # needed to control the cue/target matches anyway
+                    same_color_check = True
+                    while same_color_check:
+                        for distractor in distr_ind:
+
+                            np.random.shuffle(
+                                chunk
+                            )  # Re-randomize index for every distractor
+
+                            #Iteration for each random row, and keeping the number of repetition to so we can split the chunk in half
+                            for rand_row, iteR in zip(chunk,
+                                                      range(len(chunk))):
+
+                                if iteR >= int(
+                                        len(chunk) / 2
+                                ):  # For second half of interval, put distractor color different to the target color
+                                    matrix[rand_row,
+                                           distractor] = np.random.choice([
+                                               x for x in colors
+                                               if x != matrix[rand_row, 1]
+                                           ])
+                                else:
+                                    # For the first half of random index interval, put distractor color EQUAL to the target color
+                                    matrix[rand_row,
+                                           distractor] = matrix[rand_row, 1]
+
+                            # Perform the check of the color only if activated. If not, break.
+                            if not control_same_color and distractor == distr_ind[
+                                    -1]:
+                                same_color_check = False
+                                break
+
+                            else:
+                                if distractor == distr_ind[
+                                        -1]:  # Perform the check only while filling the last distractor.
+                                    bool_vect = []
+                                    for rand_row in chunk:
+                                        # If a row with cue of the same colors is found, stop checking and re-randomize everything.
+                                        if matrix[rand_row, 2] == matrix[
+                                                rand_row,
+                                                3] == matrix[rand_row, 4]:
+                                            bool_vect.append(1)
+                                            break
+                                        else:
+                                            bool_vect.append(0)
+                                    if sum(bool_vect) == 0:
+                                        same_color_check = False
+
+    #this just prints out probabilities to check, beware participants do not see this!!
+    else:  #implicit task
+        if not practice:
+            for i in set(matrix[:, -5]):
+                matrix_id = matrix[matrix[:, -5] == i]
+                frequency_id = round(
+                    len(matrix_id[matrix_id[:, 1] == i]) / len(matrix_id) *
+                    100, 2)
+                print(
+                    '\nFrequency of color %s where cue_identity is %s is %s%%\n'
+                    % (i, i, frequency_id))
+            print('\nCue identity levels: {}\n\n'.format(cue_validity_all))
+
+################################################################
+##     CHECK FREQUENCIES FOR DISTRACTOR CUE RANDOMIZATION     ##
+################################################################
+
+#Uncomment the prints below to show!
+
+    if not implicit:
+        c0_id0 = 0
+        c0_id1 = 0
+        c0_id2 = 0
+
+        c1_id0 = 0
+        c1_id1 = 0
+        c2_id2 = 0
+
+        c2_id0 = 0
+        c2_id1 = 0
+        c1_id2 = 0
+
+        tot_id0 = 0
+        tot_id1 = 0
+        tot_id2 = 0
+        same_col_cues = 0
+
+        diff_3_cues = 0
+        diff_2_cues = 0
+
+        for i in range(len(matrix)):
+            #        if matrix[i,2] == matrix[i,3] == matrix[i,4]:
+            #            same_col_cues += 1
+
+            if matrix[i, -5] == 0:
+                tot_id0 += 1
+                if matrix[i, 3] == matrix[i, 1]:
+                    c1_id0 += 1
+                if matrix[i, 4] == matrix[i, 1]:
+                    c2_id0 += 1
+                if matrix[i, 2] == matrix[i, 1]:
+                    c0_id0 += 1
+
+            if matrix[i, -5] == 1:
+                tot_id1 += 1
+                if matrix[i, 2] == matrix[i, 1]:
+                    c0_id1 += 1
+                if matrix[i, 4] == matrix[i, 1]:
+                    c2_id1 += 1
+                if matrix[i, 3] == matrix[i, 1]:
+                    c1_id1 += 1
+
+            if matrix[i, -5] == 2:
+                tot_id2 += 1
+                if matrix[i, 2] == matrix[i, 1]:
+                    c0_id2 += 1
+                if matrix[i, 3] == matrix[i, 1]:
+                    c1_id2 += 1
+                if matrix[i, 4] == matrix[i, 1]:
+                    c2_id2 += 1
+
+            if len(set(matrix[i, 2:5])) == 3:
+                diff_3_cues += 1
+            elif len(set(matrix[i, 2:5])) == 2:
+                diff_2_cues += 1
+            else:
+                same_col_cues += 1
+
+        same_col_cue_percentage = round(same_col_cues / trials_total * 100, 1)
+        diff_3_cues_percentage = round(diff_3_cues / trials_total * 100, 1)
+        diff_2_cues_percentage = round(diff_2_cues / trials_total * 100, 1)
+
+        cue_0_mean = round(np.mean(color_cue0), 2)
+        cue_1_mean = round(np.mean(color_cue1), 2)
+        cue_2_mean = round(np.mean(color_cue2), 2)
+        color_target_mean = round(np.mean(color_target), 2)
+
+        print('\n\nDataframe %s:\
+            \nTimes distractors are equal to color target when cue id = 0: c1 = %s%% and c2 = %s%% on total of %s (predictive cue: %s%%)\
+            \nTimes distractors are equal to color target when cue id = 1: c0 = %s%% and c2 = %s%% on total of %s (predictive cue: %s%%)\
+            \nTimes distractors are equal to color target when cue id = 2: c0 = %s%% and c1 = %s%% on total of %s (predictive cue: %s%%)\n\n\
+        mean color cue0 = %s,   mean color cue1 = %s,   mean color cue2 = %s, mean color target = %s\n\n\
+        Trials with 3 different cues = %s%%\n\
+        Trials with 2 cues of the same color = %s%%\n\
+        Trials with three cues of the same color: %s (percentage = %s%%)\n\n\
+        ' % (part_num, c1_id0 * 100 // tot_id0, c2_id0 * 100 // tot_id0,
+             tot_id0, c0_id0 * 100 // tot_id0, c0_id1 * 100 // tot_id1,
+             c2_id1 * 100 // tot_id1, tot_id1, c1_id1 * 100 // tot_id1,
+             c0_id2 * 100 // tot_id2, c1_id2 * 100 // tot_id2, tot_id2,
+             c2_id2 * 100 // tot_id2, cue_0_mean, cue_1_mean, cue_2_mean,
+             color_target_mean, diff_3_cues_percentage, diff_2_cues_percentage,
+             same_col_cues, same_col_cue_percentage))
+
+    #################################
+    ##     EXPORT TO DATAFRAME     ##
+    #################################
+
+    df = pd.DataFrame(matrix, columns=headers)
+
+    if practice:
+        df.to_csv(path_or_buf=df_name)
+        print('Practice dataframe %s exported in %s\n' % (part_num, df_name))
+    else:
+        df.to_csv(path_or_buf=df_name)
+        print('Dataframe %s exported in %s\n' % (part_num, df_name))
+    time.sleep(.5)


### PR DESCRIPTION
- Implicit and explicit version have been unified in a single script
- (almost) every parameter can (and should) be set from the init script
- (almost) all the messages are now in a separate file, it will be easier to check translations/text and the experimental procedure is more clean

TODO:
- Smooth transaction b/w practice and real experiment - if we want that
- We could use colorspace rgb255 to avoid messing with the '1' in init script - colorspace variable
- Don't save all the lines every X trials, just save the last X lines in the csv
- Feedback on mistakes and on misses
- Find a way to initialize a psychopy stimulus once, then create a new one from that with changed only some parameters. There is already a solution like this in the script, it can be extended to the other stimuli to reduce repeated code lines